### PR TITLE
Prevent file descriptor leak and modernize BufferedWriter creation

### DIFF
--- a/java/com/google/aggregate/protocol/avro/AvroResultsDeserializerRunner.java
+++ b/java/com/google/aggregate/protocol/avro/AvroResultsDeserializerRunner.java
@@ -29,6 +29,7 @@ import com.google.inject.Inject;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 
 /** Reads an Avro results file and writes a CSV of the data */
@@ -53,7 +54,7 @@ final class AvroResultsDeserializerRunner {
   private void runResultDeserialization(AvroResultsDeserializerRunnerArgs args) throws IOException {
     ImmutableList<AggregatedFact> writtenResults =
         reader.readAvroResultsFile(Paths.get(args.getResultsFilePath()));
-    BufferedWriter writer = new BufferedWriter(new FileWriter(args.getOutputPath()));
+    BufferedWriter writer = Files.newBufferedWriter(args.getOutputPath().toPath());
     writer.write("bucket,metric" + "\n");
     for (AggregatedFact fact : writtenResults) {
       writer.write(formatOutput(fact, args.isOutputBucketAsHex()) + "\n");


### PR DESCRIPTION
This change prevents a file descriptor leak and modernizes the file writing API pattern.

The way the code is written now, the [FileWriter](https://docs.oracle.com/javase/8/docs/api/java/io/FileWriter.html) never gets closed. Thus, it is up to the garbage collector's objection finalization process to close them at some point. This is not a good practice, and it can lead to a file descriptor leak. In hot code paths, it could cause exhaustion of all the available file descriptors for the system and lead to denial-of-service conditions.

Our changes look something like this:

```diff
-  BufferedWriter writer = new BufferedWriter(new FileWriter(f));
+  BufferedWriter writer = Files.newBufferedWriter(f.toPath());
```

<details>
  <summary>More reading</summary>

  * [https://cwe.mitre.org/data/definitions/775.html](https://cwe.mitre.org/data/definitions/775.html)
</details>

🧚🤖  Powered by Pixeebot  

💬[Feedback](https://ask.pixee.ai/feedback) | 👥[Community](https://pixee-community.slack.com/signup#/domain-signup) | 📚[Docs](https://docs.pixee.ai/) | Codemod ID: [pixee:java/prevent-filewriter-leak-with-nio](https://docs.pixee.ai/codemods/java/pixee_java_prevent-filewriter-leak-with-nio) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2Faggregation-service%7C28dd4e56fb079837399c07e2bd563d586e1678e1)


<!--{"type":"DRIP","codemod":"pixee:java/prevent-filewriter-leak-with-nio"}-->